### PR TITLE
Add fetch-depth to actions/checkout@v3

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -79,6 +83,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -108,6 +114,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
 `actions/checkout@v2` 以降は depth 1 でcheckoutが行われるようになりました。

Ray.Compiler で以下のようなエラーになってしまい、このテンプレートが使えなかったので `fetch-depth: 0` を指定しました。

```
Loading composer repositories with package information
Info from [https://repo.packagist.org:](https://repo.packagist.org/) #StandWithUkraine
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires ray/di ^2.x-dev -> satisfiable by ray/di[2.x-dev].
    - ray/di 2.x-dev requires ray/compiler ^1.7 -> satisfiable by ray/compiler[1.7.0, ..., 1.x-dev] from composer repo (https://repo.packagist.org/) but ray/compiler is the root package and cannot be modified. See https://getcomposer.org/dep-on-root for details and assistance.

Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires ray/di ^2.x-dev -> satisfiable by ray/di[2.x-dev].
    - ray/di 2.x-dev requires ray/compiler ^1.7 -> satisfiable by ray/compiler[1.7.0, ..., 1.x-dev] from composer repo (https://repo.packagist.org/) but ray/compiler is the root package and cannot be modified. See https://getcomposer.org/dep-on-root for details and assistance.

Error: Process completed with exit code 2.
```

https://github.com/NaokiTsuchiya/Ray.Compiler/commits/ci/php82