### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
   workflow_call:
-    inputs:
-      php_version:
-        required: true
-        type: string
 
 jobs:
   coding-standards:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,6 +6,12 @@ on:
       - '**.md'
   pull_request:
   workflow_dispatch:
+    inputs:
+      has_crc_config:
+        required: false
+        default: false
+        type: boolean
+        description: True if the project has composer_require_checker.json
   workflow_call:
     inputs:
       has_crc_config:


### PR DESCRIPTION
related

- https://github.com/bearsunday/BEAR.Resource/actions/runs/8826330272/workflow
  - `The workflow is not valid. .github/workflows/static-analysis.yml (Line: 11, Col: 5): Unexpected value 'has_crc_config'`
- https://github.com/bearsunday/BEAR.Resource/actions/runs/8826330278/workflow
  - `The workflow is not valid. .github/workflows/coding-standards.yml (Line: 10, Col: 11): Input php_version is required, but not provided while calling.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the `php_version` input configuration from the GitHub Actions workflow to streamline processes.
- **New Features**
	- Added an optional `has_crc_config` parameter to enhance workflow customization in GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->