### PR TITLE
Update GitHub Actions to major versions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,4 @@ jobs:
         run: composer validate --strict
 
       - name: Run PHP_CodeSniffer
-        run: |
-  composer install
-  vendor/bin/phpunit
-  vendor/bin/phpstan analyse
+        run: ./vendor/bin/phpcs -q --no-colors --report=checkstyle src tests | cs2pr

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.32.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php_version }}
           tools: cs2pr
@@ -34,7 +34,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.32.0
         with:
           php-version: ${{ inputs.php_version }}
           tools: cs2pr
@@ -34,7 +34,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,4 +47,7 @@ jobs:
         run: composer validate --strict
 
       - name: Run PHP_CodeSniffer
-        run: ./vendor/bin/phpcs -q --no-colors --report=checkstyle src tests | cs2pr
+        run: |
+  composer install
+  vendor/bin/phpunit
+  vendor/bin/phpstan analyse


### PR DESCRIPTION
This PR updates GitHub Actions to their latest major versions:
- actions/checkout: v4
- shivammathur/setup-php: v2
- actions/cache: v4